### PR TITLE
Use file-scoped namespaces

### DIFF
--- a/src/Lunaris.Core/Attributes.cs
+++ b/src/Lunaris.Core/Attributes.cs
@@ -1,40 +1,38 @@
 using System;
 
-namespace Lunaris
+namespace Lunaris;
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class ServiceAttribute : Attribute
 {
-    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    public sealed class ServiceAttribute : Attribute
-    {
-    }
+}
 
-    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    public sealed class SettingAttribute : Attribute
-    {
-    }
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class SettingAttribute : Attribute
+{
+}
 
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-    public sealed class DependsOnAttribute : Attribute
-    {
-        public Type DependencyType { get; }
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public sealed class DependsOnAttribute : Attribute
+{
+    public Type DependencyType { get; }
 
-        public DependsOnAttribute(Type dependencyType)
-        {
-            DependencyType = dependencyType;
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    public class MessageAttribute : Attribute
+    public DependsOnAttribute(Type dependencyType)
     {
+        DependencyType = dependencyType;
     }
+}
 
-    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    public sealed class CommandAttribute : MessageAttribute
-    {
-    }
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public class MessageAttribute : Attribute
+{
+}
 
-    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    public sealed class NotificationAttribute : MessageAttribute
-    {
-    }
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class CommandAttribute : MessageAttribute
+{
+}
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class NotificationAttribute : MessageAttribute
+{
 }

--- a/src/Lunaris.Core/ICommandHandler.cs
+++ b/src/Lunaris.Core/ICommandHandler.cs
@@ -1,10 +1,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Lunaris
+namespace Lunaris;
+public interface ICommandHandler<TCommand>
 {
-    public interface ICommandHandler<TCommand>
-    {
-        Task HandleAsync(TCommand command, CancellationToken cancellationToken = default);
-    }
+    Task HandleAsync(TCommand command, CancellationToken cancellationToken = default);
 }

--- a/src/Lunaris.Core/IMessagePipeline.cs
+++ b/src/Lunaris.Core/IMessagePipeline.cs
@@ -2,10 +2,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Lunaris
+namespace Lunaris;
+public interface IMessagePipeline
 {
-    public interface IMessagePipeline
-    {
-        Task InvokeAsync(object message, Func<Task> next, CancellationToken cancellationToken = default);
-    }
+    Task InvokeAsync(object message, Func<Task> next, CancellationToken cancellationToken = default);
 }

--- a/src/Lunaris.Runtime/MessageDispatcher.cs
+++ b/src/Lunaris.Runtime/MessageDispatcher.cs
@@ -3,21 +3,19 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Lunaris
+namespace Lunaris;
+public class MessageDispatcher
 {
-    public class MessageDispatcher
+    private readonly IServiceProvider _provider;
+
+    public MessageDispatcher(IServiceProvider provider)
     {
-        private readonly IServiceProvider _provider;
+        _provider = provider;
+    }
 
-        public MessageDispatcher(IServiceProvider provider)
-        {
-            _provider = provider;
-        }
-
-        public async Task DispatchAsync<TCommand>(TCommand command, CancellationToken token = default)
-        {
-            var handler = _provider.GetRequiredService<ICommandHandler<TCommand>>();
-            await handler.HandleAsync(command, token);
-        }
+    public async Task DispatchAsync<TCommand>(TCommand command, CancellationToken token = default)
+    {
+        var handler = _provider.GetRequiredService<ICommandHandler<TCommand>>();
+        await handler.HandleAsync(command, token);
     }
 }

--- a/src/Lunaris.Runtime/ServiceCollectionExtensions.cs
+++ b/src/Lunaris.Runtime/ServiceCollectionExtensions.cs
@@ -2,27 +2,25 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Lunaris
+namespace Lunaris;
+public static class ServiceCollectionExtensions
 {
-    public static class ServiceCollectionExtensions
+    public static IServiceCollection AddLunaris(this IServiceCollection services, params Assembly[] assemblies)
     {
-        public static IServiceCollection AddLunaris(this IServiceCollection services, params Assembly[] assemblies)
+        if (assemblies == null || assemblies.Length == 0)
         {
-            if (assemblies == null || assemblies.Length == 0)
-            {
-                assemblies = new[] { Assembly.GetCallingAssembly() };
-            }
-
-            var serviceTypes = assemblies
-                .SelectMany(a => a.GetTypes())
-                .Where(t => t.GetCustomAttribute<ServiceAttribute>() != null);
-
-            foreach (var type in serviceTypes)
-            {
-                services.AddTransient(type);
-            }
-
-            return services;
+            assemblies = new[] { Assembly.GetCallingAssembly() };
         }
+
+        var serviceTypes = assemblies
+            .SelectMany(a => a.GetTypes())
+            .Where(t => t.GetCustomAttribute<ServiceAttribute>() != null);
+
+        foreach (var type in serviceTypes)
+        {
+            services.AddTransient(type);
+        }
+
+        return services;
     }
 }


### PR DESCRIPTION
## Summary
- switch to file-scoped namespaces across runtime and core

## Testing
- `dotnet test tests/Lunaris.Tests/Lunaris.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6846d9b05b088324a1dc152182bfd1cd